### PR TITLE
bump source-tag & deps

### DIFF
--- a/1.24.3/rockcraft.yaml
+++ b/1.24.3/rockcraft.yaml
@@ -4,7 +4,7 @@
 name: install-cni
 summary: Istio's install-cni in a rock
 description: "Installs Istio's cni plugin"
-version: "1.24.1"
+version: "1.24.3"
 base: ubuntu@24.04
 build-base: ubuntu@24.04
 services:
@@ -29,9 +29,9 @@ parts:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
-    source-tag: "1.24.1"
+    source-tag: "1.24.3"
     build-snaps:
-      - go/1.22/stable
+      - go/1.23/stable
     override-build: |
       GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=agent,disable_pgv ./cni/cmd/istio-cni ./cni/cmd/install-cni
 


### PR DESCRIPTION
## Issue
Fix for https://github.com/canonical/oci-factory/actions/runs/13135280054/attempts/1#summary-36649577373 

## Solution
Bump upstream source tags to `1.24.3` before on-boarding to OCI factory
