### PR TITLE
feat(ci): migrate to ci v1

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,5 +12,5 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@v1
     secrets: inherit

--- a/.github/workflows/rock-release-dev.yaml
+++ b/.github/workflows/rock-release-dev.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@v1
     secrets: inherit
     with:
       rock-name: istio-install-cni

--- a/.github/workflows/rock-release-oci-factory.yaml
+++ b/.github/workflows/rock-release-oci-factory.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@v1
     secrets: inherit
     with:
       rock-name: istio-install-cni

--- a/.github/workflows/rock-update.yaml
+++ b/.github/workflows/rock-update.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    uses: canonical/observability/.github/workflows/rock-update.yaml@v0
+    uses: canonical/observability/.github/workflows/rock-update.yaml@v1
     with:
       rock-name: istio-install-cni
       source-repo: istio/istio

--- a/1.23.3/rockcraft.yaml
+++ b/1.23.3/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Rock for [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
 # This image's purpose is described [here](https://github.com/istio/istio/tree/master/cni#overview)
 
-name: install-cni
+name: istio-install-cni
 summary: Istio's install-cni in a rock
 description: "Installs Istio's cni plugin"
 version: "1.23.3"
@@ -25,7 +25,7 @@ environment:
 parts:
   # [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni)
   # build instructions lifted from the makefile [here](https://github.com/istio/istio/blob/master/Makefile.core.mk#L246)
-  install-cni:
+  istio-install-cni:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
@@ -60,7 +60,7 @@ parts:
   deb-security-manifest:
     plugin: nil
     after:
-      - install-cni
+      - istio-install-cni
       - stage-dependency-packages
       - ca-certs
     override-prime: |

--- a/1.26.1/rockcraft.yaml
+++ b/1.26.1/rockcraft.yaml
@@ -4,7 +4,7 @@
 name: istio-install-cni
 summary: Istio's install-cni in a rock
 description: "Installs Istio's cni plugin"
-version: "1.24.3"
+version: "1.26.1"
 base: ubuntu@24.04
 build-base: ubuntu@24.04
 services:
@@ -29,9 +29,9 @@ parts:
     plugin: go
     source: https://github.com/istio/istio
     source-type: git
-    source-tag: "1.24.3"
+    source-tag: "1.26.1"
     build-snaps:
-      - go/1.23/stable
+      - go/1.24/stable
     override-build: |
       GOOS=linux GOARCH=amd64 LDFLAGS='-extldflags -static -s -w' common/scripts/gobuild.sh ./out/linux_amd64/ -tags=agent,disable_pgv ./cni/cmd/istio-cni ./cni/cmd/install-cni
 
@@ -40,7 +40,7 @@ parts:
 
       mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin
       cp out/linux_amd64/install-cni ${CRAFT_PART_INSTALL}/usr/local/bin
-      
+
   # install packages provided by the istio/iptables distroless image, which is a base for install-cni
   # as seen [here](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
   # The base image is defined [here](https://github.com/istio/istio/blob/master/docker/iptables.yaml) using apko,

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 set quiet # Recipes are silent by default
 set export # Just variables are exported to environment variables
 
-rock_name := `echo ${PWD##*/} | sed 's/^istio-//;s/-rock//'`
+rock_name := `awk '/^name:/{print $2}' */rockcraft.yaml | head -1`
 latest_version := `find . -maxdepth 1 -type d | sort -V | tail -n1 | sed 's@./@@'`
 
 [private]


### PR DESCRIPTION
## Issue

Migrates ci to v1

And

i. Fixes the rock naming - the names were mismatching between the `rock-name` used in the ci, the rock name used in the `rockcraft.yaml` and the part name used in the OCI image. This was basically causing all the rock workflows to fail (informed guess, looking at the central ci files since we dont have any workflow logs anymore since its been forever since any of the workflows ran)  It is now all standardized and matches the upstream artificat name with the `istio-` prefix.
ii. Adds a rock for `v1.26.1` which is what the current charms are using