### PR TITLE
chore: pin workflows to main

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,5 +12,5 @@ concurrency:
 jobs:
   pull-request:
     name: Pull Requests
-    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-pull-request.yaml@main
     secrets: inherit

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -13,5 +13,5 @@ concurrency:
 jobs:
   release-dev:
     name: Release to GHCR
-    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-release-dev.yaml@main
     secrets: inherit

--- a/.github/workflows/release-oci-factory.yaml
+++ b/.github/workflows/release-oci-factory.yaml
@@ -9,5 +9,5 @@ on:
 jobs:
   release-oci-factory:
     name: Release to OCI Factory
-    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@main
     secrets: inherit

--- a/1.29.0/rockcraft.yaml
+++ b/1.29.0/rockcraft.yaml
@@ -1,5 +1,5 @@
 # Rock for [install-cni](https://github.com/istio/istio/blob/master/cni/deployments/kubernetes/Dockerfile.install-cni).
-# This image's purpose is described [here](https://github.com/istio/istio/tree/master/cni#overview)
+# The purpose of this image is described [here](https://github.com/istio/istio/tree/master/cni#overview)
 
 name: istio-install-cni
 summary: Istio's install-cni in a rock


### PR DESCRIPTION
## Issue
Removes the pin from the workflows and pins it to the main branch as per Luca's advice
(Small comment change in the rockcraft yaml to check if the push to oci factory is working)
