### PR TITLE
chore: rollback baseimage

### DIFF
--- a/1.29.0/rockcraft.yaml
+++ b/1.29.0/rockcraft.yaml
@@ -5,8 +5,8 @@ name: istio-install-cni
 summary: Istio's install-cni in a rock
 description: "Installs Istio's cni plugin"
 version: "1.29.0"
-base: ubuntu@26.04
-build-base: ubuntu@26.04
+base: ubuntu@24.04
+build-base: ubuntu@24.04
 services:
   install-cni:
     command: "/usr/local/bin/install-cni"


### PR DESCRIPTION
rollsback v1.29 to ubuntu 2404 baseimage